### PR TITLE
feat: add skip_files config to exclude files via sparse-checkout

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,7 @@ dof supports configuration in several ways:
 
 The default config file is `$HOME/.dof.yaml`.
 
-Profiles are defined under `profiles.<name>` and can override `repository` and `branch`.
+Profiles are defined under `profiles.<name>` and can override `repository`, `branch`, and `skip_files`.
 
 The `--profile` flag selects one named profile from this single config file. That means you can keep multiple repository definitions in one shared config and switch between them at runtime.
 
@@ -71,10 +71,16 @@ Example config:
 ----
 repository: /home/user/.dof
 branch: main
+skip_files:
+  - README.md
+  - LICENSE
 profiles:
   work:
     repository: /home/user/.dof-work
     branch: work
+    skip_files:
+      - scm-info.yaml
+      - README.adoc
   personal:
     repository: /home/user/.dof-personal
     branch: main
@@ -84,6 +90,59 @@ Use profiles like this:
 
 * `dof --profile work init`
 * `dof --profile personal sync`
+
+=== Adding a profile
+
+To add a new profile, open `$HOME/.dof.yaml` and add an entry under `profiles`:
+
+[source,yaml]
+----
+profiles:
+  myprofile:
+    repository: /home/user/.dof-myprofile
+    branch: main
+    skip_files:
+      - README.md
+----
+
+Each profile can set any combination of `repository`, `branch`, and `skip_files`. Values you omit fall back to the top-level defaults.
+
+Then use the profile with `--profile myprofile`:
+
+[source,shell]
+----
+dof --profile myprofile init
+dof --profile myprofile checkout git@github.com:user/dotfiles.git
+dof --profile myprofile sync
+----
+
+=== Skipping files
+
+Some dotfile repositories contain files that are useful on the remote (e.g. `README.md`, `LICENSE`, `scm-info.yaml`) but should not appear in the home directory. The `skip_files` option excludes these files from the working tree.
+
+Add the files you want to skip to your config:
+
+[source,yaml]
+----
+skip_files:
+  - README.md
+  - README.adoc
+  - LICENSE
+  - scm-info.yaml
+----
+
+This works by setting up git sparse-checkout in non-cone mode. Once applied, the excluded files stay absent across all git operations (checkout, pull, merge) without any extra wrapper logic.
+
+The skip rules are applied automatically when you run `dof init` or `dof checkout`. If you change the `skip_files` list later, run `dof init` again to update the sparse-checkout rules.
+
+To add `skip_files` to an existing repository that was already initialized, just add the list to your `$HOME/.dof.yaml` and run:
+
+[source,shell]
+----
+dof init
+----
+
+This re-applies the sparse-checkout rules and removes the skipped files from your working tree. The files remain tracked in git and are still pushed to the remote — they just do not appear locally.
 
 == Command overview
 

--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -64,7 +64,11 @@ Example:
 		logger.Info("Checkout branch...")
 		gitCheckout := *gitAlias
 		gitCheckout.Args = append(gitCheckout.Args, "checkout", viper.GetString("branch"))
-		return execCmdAndPrint(&gitCheckout)
+		if err := execCmdAndPrint(&gitCheckout); err != nil {
+			return err
+		}
+
+		return applySkipFiles()
 	},
 }
 
@@ -87,8 +91,13 @@ func renameOldFiles() error {
 		return err
 	}
 	files := strings.Split(filesString, "\n")
+	skipFiles := viper.GetStringSlice("skip_files")
 	for _, file := range files {
 		if file == "" {
+			continue
+		}
+		if isSkipped(file, skipFiles) {
+			logger.Infof("Skipping %s (in skip_files)", file)
 			continue
 		}
 		logger.Infof("Rename %s to %s", path.Join(workDir, file), path.Join(workDir, file+"_before_dof"))

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -268,6 +268,7 @@ func TestApplyProfile(t *testing.T) {
 			viper.Reset()
 			viper.SetDefault("repository", "/default/.dof")
 			viper.SetDefault("branch", "main")
+			viper.SetDefault("skip_files", []string{})
 			tt.setupConfig()
 
 			applyProfile(tt.profile)
@@ -276,4 +277,104 @@ func TestApplyProfile(t *testing.T) {
 			assert.Equal(t, tt.wantBranch, viper.GetString("branch"))
 		})
 	}
+}
+
+func TestApplyProfileWithSkipFiles(t *testing.T) {
+	viper.Reset()
+	viper.SetDefault("repository", "/default/.dof")
+	viper.SetDefault("branch", "main")
+	viper.SetDefault("skip_files", []string{})
+	viper.Set("profiles.work.repository", "/tmp/work-dof")
+	viper.Set("profiles.work.skip_files", []string{"README.md", "LICENSE"})
+
+	applyProfile("work")
+
+	assert.Equal(t, []string{"README.md", "LICENSE"}, viper.GetStringSlice("skip_files"))
+}
+
+func TestIsSkipped(t *testing.T) {
+	tests := []struct {
+		name      string
+		file      string
+		skipFiles []string
+		want      bool
+	}{
+		{
+			name:      "file is in skip list",
+			file:      "README.md",
+			skipFiles: []string{"README.md", "LICENSE"},
+			want:      true,
+		},
+		{
+			name:      "file is not in skip list",
+			file:      ".zshrc",
+			skipFiles: []string{"README.md", "LICENSE"},
+			want:      false,
+		},
+		{
+			name:      "empty skip list",
+			file:      "README.md",
+			skipFiles: []string{},
+			want:      false,
+		},
+		{
+			name:      "nil skip list",
+			file:      "README.md",
+			skipFiles: nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSkipped(tt.file, tt.skipFiles))
+		})
+	}
+}
+
+func TestApplySkipFilesEmpty(t *testing.T) {
+	setupTestEnv(t)
+	viper.Set("skip_files", []string{})
+
+	err := applySkipFiles()
+	require.NoError(t, err)
+}
+
+func TestApplySkipFiles(t *testing.T) {
+	tmpDir := setupTestEnv(t)
+	repoPath := filepath.Join(tmpDir, ".dof")
+
+	err := os.MkdirAll(repoPath, 0700)
+	require.NoError(t, err)
+
+	err = initCmd.RunE(initCmd, nil)
+	require.NoError(t, err)
+
+	// Add a README.md to the repo
+	readmeFile := filepath.Join(tmpDir, "README.md")
+	err = os.WriteFile(readmeFile, []byte("# My Dotfiles"), 0600)
+	require.NoError(t, err)
+
+	gitAlias = exec.Command("git", "--git-dir="+repoPath, "--work-tree="+tmpDir)
+	err = addCmd.RunE(addCmd, []string{readmeFile})
+	require.NoError(t, err)
+
+	// Now configure skip_files and apply
+	viper.Set("skip_files", []string{"README.md"})
+	gitAlias = exec.Command("git", "--git-dir="+repoPath, "--work-tree="+tmpDir)
+
+	err = applySkipFiles()
+	require.NoError(t, err)
+
+	// Verify README.md was removed from working tree
+	assert.NoFileExists(t, readmeFile)
+
+	// Verify sparse-checkout file was written
+	sparseFile := filepath.Join(repoPath, "info", "sparse-checkout")
+	assert.FileExists(t, sparseFile)
+
+	content, err := os.ReadFile(sparseFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "/*")
+	assert.Contains(t, string(content), "!README.md")
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -79,7 +79,7 @@ Example usage:
 			}
 		}
 
-		return nil
+		return applySkipFiles()
 	},
 }
 
@@ -164,4 +164,63 @@ func doNotShowUntrackedFiles() error {
 	gitConfigArgs := []string{"config", "--local", "status.showUntrackedFiles", "no"}
 	gitConfigure.Args = append(gitConfigure.Args, gitConfigArgs...)
 	return execCmdAndPrint(&gitConfigure)
+}
+
+func applySkipFiles() error {
+	skipFiles := viper.GetStringSlice("skip_files")
+	if len(skipFiles) == 0 {
+		return nil
+	}
+
+	logger.Info("Configuring sparse-checkout to skip files...")
+
+	// Enable sparse-checkout in non-cone mode
+	gitConfig := *gitAlias
+	gitConfig.Args = append(gitConfig.Args, "config", "--local", "core.sparseCheckout", "true")
+	if err := execCmdAndPrint(&gitConfig); err != nil {
+		return fmt.Errorf("failed to enable sparse-checkout: %w", err)
+	}
+
+	// Write sparse-checkout patterns: include all, then exclude each skip file
+	sparseFile := path.Join(viper.GetString("repository"), "info", "sparse-checkout")
+	if err := os.MkdirAll(path.Dir(sparseFile), 0700); err != nil {
+		return fmt.Errorf("failed to create info directory: %w", err)
+	}
+
+	file, err := os.Create(sparseFile)
+	if err != nil {
+		return fmt.Errorf("failed to create sparse-checkout file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	writer := bufio.NewWriter(file)
+	if _, err := writer.WriteString("/*\n"); err != nil {
+		return fmt.Errorf("failed to write sparse-checkout pattern: %w", err)
+	}
+	for _, skip := range skipFiles {
+		if _, err := writer.WriteString("!" + skip + "\n"); err != nil {
+			return fmt.Errorf("failed to write sparse-checkout pattern: %w", err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("failed to flush sparse-checkout file: %w", err)
+	}
+
+	// Apply sparse-checkout to working tree
+	gitReadTree := *gitAlias
+	gitReadTree.Args = append(gitReadTree.Args, "read-tree", "-mu", "HEAD")
+	if err := execCmdAndPrint(&gitReadTree); err != nil {
+		return fmt.Errorf("failed to apply sparse-checkout: %w", err)
+	}
+
+	return nil
+}
+
+func isSkipped(file string, skipFiles []string) bool {
+	for _, skip := range skipFiles {
+		if file == skip {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,7 @@ func initFlags() {
 
 	viper.SetDefault("repository", path.Join(userHomeDir, ".dof"))
 	viper.SetDefault("branch", "main")
+	viper.SetDefault("skip_files", []string{})
 
 	// If a profile is selected, override defaults from profile config
 	if profileName != "" {
@@ -124,6 +125,9 @@ func applyProfile(name string) {
 	}
 	if branch := viper.GetString(profileKey + ".branch"); branch != "" {
 		viper.Set("branch", branch)
+	}
+	if skipFiles := viper.GetStringSlice(profileKey + ".skip_files"); len(skipFiles) > 0 {
+		viper.Set("skip_files", skipFiles)
 	}
 }
 

--- a/spec/design.md
+++ b/spec/design.md
@@ -96,6 +96,43 @@ Configuration is managed by **viper** with the following precedence
 On every successful run the merged config is written back to the YAML
 file via `viper.WriteConfig()`.
 
+### 4.1 Skip Files (Sparse Checkout)
+
+The `skip_files` option is a list of file paths to exclude from the
+working tree. It maps to git's sparse-checkout feature in non-cone
+(pattern) mode.
+
+**Config example (`$HOME/.dof.yaml`):**
+
+```yaml
+repository: /home/user/.dof
+branch: main
+skip_files:
+  - README.md
+  - LICENSE
+  - scm-info.yaml
+
+profiles:
+  work:
+    repository: /home/user/.dof-work
+    skip_files:
+      - README.adoc
+```
+
+**Implementation:** A helper function `applySkipFiles()` in `init.go`:
+
+1. Reads `skip_files` from viper (string slice, default empty).
+2. If the list is empty, disables sparse-checkout and returns.
+3. Enables sparse-checkout in non-cone mode.
+4. Writes patterns: `/*` (include all) followed by `!<file>` for each
+   entry.
+5. Runs `git read-tree -mu HEAD` to apply the rules to the working
+   tree.
+
+This function is called at the end of `dof init` and `dof checkout`.
+Once set, git pull/merge automatically respects sparse-checkout rules,
+so `dof sync` needs no extra logic.
+
 ## 5. Git Command Execution
 
 A global `*exec.Cmd` template (`gitAlias`) is built once during flag

--- a/spec/requirements.md
+++ b/spec/requirements.md
@@ -142,3 +142,22 @@ home directory without turning `$HOME` into a regular git repo.
 - Conflicting or redundant flags are removed.
 - Flag names follow a consistent naming convention.
 - Verify that all defined flags work as intended
+
+### REQ-13 Skip files from checkout
+
+> As a user, I want to exclude certain files (e.g. `README.md`,
+> `LICENSE`, `scm-info.yaml`) from being checked out into my working
+> tree so that repository metadata does not clutter my home directory.
+
+**Acceptance criteria:**
+
+- A `skip_files` list can be configured in the config file, via
+  environment variable, or per profile.
+- Files listed in `skip_files` are not checked out to the working tree.
+- `dof checkout` applies the skip list after cloning.
+- `dof init` applies the skip list after initialising.
+- `dof sync` (pull) respects the skip list — skipped files stay absent.
+- The feature uses git sparse-checkout so the exclusion persists across
+  git operations without additional wrapper logic.
+- Changing the config and re-running `dof init` or `dof checkout`
+  updates the sparse-checkout rules.

--- a/spec/tasks.md
+++ b/spec/tasks.md
@@ -88,3 +88,19 @@ Legend: `[x]` = done, `[ ]` = to do
 
 - [x] **[Quality]** Add golangci-lint configuration and fix lint issues
   _Done when:_ `.golangci.yml` exists; `golangci-lint run` passes; CI workflow runs lint.
+
+---
+
+## 7. Skip Files (REQ-13)
+
+- [x] **[Config]** Add `skip_files` viper default and profile support
+  _Done when:_ `skip_files` is a string slice in viper defaults; `applyProfile` applies profile-level `skip_files`; tested.
+
+- [x] **[cmd/init]** Apply sparse-checkout after init when `skip_files` is set
+  _Done when:_ `dof init` with `skip_files` configured writes sparse-checkout patterns and removes excluded files from the working tree; tested.
+
+- [x] **[cmd/checkout]** Apply sparse-checkout after checkout and skip backup of excluded files
+  _Done when:_ `dof checkout` skips renaming files in `skip_files` and applies sparse-checkout after checkout; tested.
+
+- [x] **[Testing]** Add unit tests for `isSkipped` and `applySkipFiles`
+  _Done when:_ Tests cover empty list, matching files, non-matching files, and full sparse-checkout flow with file removal.


### PR DESCRIPTION
## Summary

Add a `skip_files` configuration option that excludes specified files from the working tree using git sparse-checkout (non-cone mode).

## Problem

Dotfile repositories often contain files like `README.md`, `LICENSE`, or `scm-info.yaml` that are useful on the remote but should not appear in the home directory.

## Solution

- New `skip_files` config option (string slice) in `$HOME/.dof.yaml`
- Uses git sparse-checkout to exclude listed files from the working tree
- Applied automatically during `dof init` and `dof checkout`
- Once set, git pull/merge respects the rules — no extra wrapper logic needed
- Supported at the top level and per profile

## Config example

```yaml
skip_files:
  - README.md
  - LICENSE
  - scm-info.yaml
```

## Changes

- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \or - \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- \- c/`- \- \- \ted requirements, design, and tasks